### PR TITLE
chore(embedder): scrub old ira.cubert_pipeline imports

### DIFF
--- a/docs/COORDINATOR.md
+++ b/docs/COORDINATOR.md
@@ -19,7 +19,7 @@ PY
 
 # 3) one-shot embed example (prints a vector)
 PYTHONPATH="$(pwd)/google-research" python - <<'PY'
-from ira.cubert_pipeline import get_cubert_embedding
+from services.embedder.src.cubert_pipeline import get_cubert_embedding
 print(get_cubert_embedding("def add(a,b): return a+b").tolist())
 PY
 ```
@@ -83,7 +83,7 @@ export function embedOnce(vpy: string, repoRoot: string, code: string) {
   const env = { ...process.env, PYTHONPATH: join(repoRoot, "google-research") };
   const py = `
 import json, sys
-from ira.cubert_pipeline import get_cubert_embedding
+from services.embedder.src.cubert_pipeline import get_cubert_embedding
 src = sys.stdin.read()
 vec = get_cubert_embedding(src)
 print(json.dumps(vec.tolist()))


### PR DESCRIPTION
Docs now reference the service module; pem_parser uses local service import with HTTP fallback.